### PR TITLE
Changes to using core-style

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,41 @@ Or [download as ZIP](https://github.com/mvaldetaro/web-loader/archive/master.zip
 Attribute | Options         | Default                    | Description
 ---       | ---             | ---                        | ---
 `type`    | `circle`, `dot`, `clock` | `circle`                   | The type of loader
-`color`   | *hex*           | `#000000`                  | The color of loader
 `display` | `block`, `none` | `block`                  | The visibility of loader
+`styleOverride` | `web-loader`, `anything-else` | `web-loader`  | Specifies the reference ID of the core-style to use for overriding default stylings
+
+## Styling
+
+Styling is done through the use of a core-style element. All you have to do is declare a core-style element in your site with an ID that matches the `styleOverride` property of the `web-loader` component (defaults to `web-loader`). 
+For example:
+```html
+  <core-style id="web-loader">
+      .circle{
+        border: 3px solid #333333;
+      }
+      .circle:after{
+        background-color: #333333;
+      }
+      .clock{
+        border: 3px solid #333333;
+      }
+      .clock:after{
+        background-color: #333333;
+      }
+      .clock:before{
+        background-color: #333333;
+      }
+      .dot{
+        background-color: #333333;
+      }
+      .dot:before{
+        background-color: #333333;
+      }
+      .dot:after{
+        background-color: #333333;
+      }
+  </core-style>
+  ```
 
 ## Browser Support
 

--- a/src/web-loader.html
+++ b/src/web-loader.html
@@ -1,15 +1,57 @@
 <link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../core-style/core-style.html" />
 
-<polymer-element name="web-loader" attributes="type color display">
+<polymer-element name="web-loader" attributes="type display styleOverride">
   <template>
-    <template id="clock" if="{{type == 'clock'}}">
-      <div class="clock" style="display: {{display}};"></div>
+      <style>
+        /* -------------- circle -------------- */
+        .circle{
+          position: relative;
+          height: 80px;
+          width: 80px;
+          border-radius: 80px;
+          border: 3px solid #95a5a6;
+
+          top: 28%;
+          top: -webkit-calc(50% - 43px);
+          top: calc(50% - 43px);
+          left: 35%;
+          left: -webkit-calc(50% - 43px);
+          left: calc(50% - 43px);
+
+          -webkit-transform-origin: 50% 50%;
+          transform-origin: 50% 50%;
+          -webkit-animation: circleAnimation 3s linear infinite;
+          animation: circleAnimation 3s linear infinite;
+        }
+
+        .circle:after{
+          content: "";
+          position: absolute;
+          top: -5px;
+          left: 20px;
+          width: 11px;
+          height: 11px;
+          border-radius: 10px;
+          background-color: #95a5a6;
+        }
+
+        @-webkit-keyframes circleAnimation{
+          0%{-webkit-transform:rotate(0deg);}
+          100%{-webkit-transform:rotate(360deg);}
+        }
+
+        @keyframes circleAnimation{
+          0%{transform:rotate(0deg);}
+          100%{transform:rotate(360deg);}
+        }
+      </style>
       <style>
         /* -------------- Clock -------------- */
 
         .clock{
           border-radius: 60px;
-          border: 3px solid {{color}};
+          border: 3px solid #95a5a6;
           height: 80px;
           width: 80px;
           position: relative;
@@ -24,7 +66,7 @@
         .clock:after{
           content: "";
           position: absolute;
-          background-color: {{color}};
+          background-color: #95a5a6;
           top:2px;
           left: 48%;
           height: 38px;
@@ -49,7 +91,7 @@
         .clock:before{
           content: "";
           position: absolute;
-          background-color: {{color}};
+          background-color: #95a5a6;
           top:6px;
           left: 48%;
           height: 35px;
@@ -71,22 +113,16 @@
           100%{transform:rotate(360deg);}
         }
       </style>
-    </template>
-    <template id="dot" if="{{type == 'dot'}}">
-      <div class="loader6" style="display: {{display}};"></div>
       <style>
-
         /*
-        author: TaniaLD;
-        url: http://codepen.io/TaniaLD/
+            author: TaniaLD;
+            url: http://codepen.io/TaniaLD/
         */
-
-        /* -------------- dot -------------- */
-        .loader6{
+        /* -----------------dot------------------ */
+        .dot{
           position: relative;
           width: 12px;
           height: 12px;
-
           top: 46%;
           top: -webkit-calc(50% - 6px);
           top: calc(50% - 6px);
@@ -95,17 +131,17 @@
           left: calc(50% - 6px);
 
           border-radius: 12px;
-          background-color: {{color}};
+          background-color: #95a5a6;
           -webkit-transform-origin:  50% 50%;
-          transform-origin:  50% 50% ;
-          -webkit-animation: loader6 1s ease-in-out infinite;
-          animation: loader6 1s ease-in-out infinite;
+          transform-origin:  50% 50%;
+          -webkit-animation: dotAnimation 1s ease-in-out infinite;
+          animation: dotAnimation 1s ease-in-out infinite;
         }
 
-        .loader6:before{
+        .dot:before{
           content: "";
           position: absolute;
-          background-color: {{color}};
+          background-color: #95a5a6;
           opacity: .5;
           top: 0px;
           left: -25px;
@@ -114,10 +150,10 @@
           border-radius: 12px;
         }
 
-        .loader6:after{
+        .dot:after{
           content: "";
           position: absolute;
-          background-color: {{color}};
+          background-color: #95a5a6;
           opacity: .5;
           top: 0px;
           left: 25px;
@@ -126,71 +162,30 @@
           border-radius: 12px;
         }
 
-        @-webkit-keyframes loader6{
+        @-webkit-keyframes dotAnimation{
           0%{-webkit-transform:rotate(0deg);}
           50%{-webkit-transform:rotate(180deg);}
           100%{-webkit-transform:rotate(180deg);}
         }
 
-        @keyframes loader6{
+        @keyframes dotAnimation{
           0%{transform:rotate(0deg);}
           50%{transform:rotate(180deg);}
           100%{transform:rotate(180deg);}
         }
       </style>
-    </template>
-    <template id="circle" if="{{type == 'circle'}}">
-      <div class="loader1" style="display: {{display}};"></div>
-      <style>
-        /* -------------- circle -------------- */
-        .loader1{
-          position: relative;
-          height: 80px;
-          width: 80px;
-          border-radius: 80px;
-          border: 3px solid {{color}};
 
-          top: 28%;
-          top: -webkit-calc(50% - 43px);
-          top: calc(50% - 43px);
-          left: 35%;
-          left: -webkit-calc(50% - 43px);
-          left: calc(50% - 43px);
 
-          -webkit-transform-origin: 50% 50%;
-          transform-origin: 50% 50%;
-          -webkit-animation: loader1 3s linear infinite;
-          animation: loader1 3s linear infinite;
-        }
+      <core-style ref="{{styleOverride}}"></core-style>
 
-        .loader1:after{
-          content: "";
-          position: absolute;
-          top: -5px;
-          left: 20px;
-          width: 11px;
-          height: 11px;
-          border-radius: 10px;
-          background-color: {{color}};
-        }
-
-        @-webkit-keyframes loader1{
-          0%{-webkit-transform:rotate(0deg);}
-          100%{-webkit-transform:rotate(360deg);}
-        }
-
-        @keyframes loader1{
-          0%{transform:rotate(0deg);}
-          100%{transform:rotate(360deg);}
-        }
-      </style>
-    </template>
+      <div class="{{type}}" style="display: {{display}};"></div>
   </template>
   <script>
     Polymer('web-loader', {
-      type: "circle",
+      type: "circle", //Dot, Circle, Clock
       color: "#95a5a6",
-      display: "block"
+      display: "block",
+      styleOverride: "web-loader"
     });
   </script>
 </polymer-element>


### PR DESCRIPTION
I made some changes to the web-loader to take advantage of the `core-style` type element instead of the inline databound style tags. The inline style tags were causing an issue with the ShadowDom polyfill in IE. Modifying the color of the elements this way doesn't cause a problem and also has the added benefit of allowing the user to override anything else they may want within the element style-wise without modifying the core element.
